### PR TITLE
Support map fields in Directus

### DIFF
--- a/templates/compose/directus-with-postgresql.yaml
+++ b/templates/compose/directus-with-postgresql.yaml
@@ -36,7 +36,7 @@ services:
       redis:
         condition: service_healthy
   postgresql:
-    image: postgres:16-alpine
+    image: postgis/postgis:16-3.4-alpine
     volumes:
       - directus-postgresql-data:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
To support the map fields in Directus with Postgres you need the Postgis extension installed, with docker we can just change the image to use the equivalent alpine postgis image, source latest stable alpine from here (perhaps there is a better ref to use than one with a specific version number?): https://registry.hub.docker.com/r/postgis/postgis/

If you are already running Directus without postgis, and would like to make use of the mapping fields after updating the docker compose file you will need to go to `execute command`, select the postgres container and run the following command filling in the appropriate env vars;

`psql -U ${SERVICE_USER_POSTGRESQL} -d ${POSTGRESQL_DATABASE} -c "CREATE EXTENSION postgis;"`

> Always use `next` branch as destination branch for PRs, not `main`
